### PR TITLE
[Windows] add support for port information

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,4 +25,17 @@ pub fn build(b: *std.build.Builder) void {
     });
     list_exe.addModule("serial", serial_mod);
     b.installArtifact(list_exe);
+
+    // TODO: Linux and MacOS port info support
+    const os_tag = list_exe.target_info.target.os.tag;
+    if (os_tag == .windows) {
+        const port_info_exe = b.addExecutable(.{
+            .name = "serial-list-info",
+            .root_source_file = .{ .path = "examples/list_port_info.zig" },
+            .target = target,
+            .optimize = optimize,
+        });
+        port_info_exe.addModule("serial", serial_mod);
+        b.installArtifact(port_info_exe);
+    }
 }

--- a/examples/list_port_info.zig
+++ b/examples/list_port_info.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const zig_serial = @import("serial");
+
+pub fn main() !u8 {
+    var iterator = try zig_serial.list_info();
+    defer iterator.deinit();
+
+    while (try iterator.next()) |info| {
+        std.debug.print("\nPort name: {s}\n", .{info.port_name});
+        std.debug.print(" - System location: {s}\n", .{info.system_location});
+        std.debug.print(" - Friendly name: {s}\n", .{info.friendly_name});
+        std.debug.print(" - Description: {s}\n", .{info.description});
+        std.debug.print(" - Manufacturer: {s}\n", .{info.manufacturer});
+        std.debug.print(" - Serial #: {s}\n", .{info.serial_number});
+        std.debug.print(" - VID: 0x{X:0>4} PID: 0x{X:0>4}\n", .{ info.vid, info.pid });
+    }
+
+    return 0;
+}

--- a/examples/list_port_info.zig
+++ b/examples/list_port_info.zig
@@ -11,7 +11,8 @@ pub fn main() !u8 {
         std.debug.print(" - Friendly name: {s}\n", .{info.friendly_name});
         std.debug.print(" - Description: {s}\n", .{info.description});
         std.debug.print(" - Manufacturer: {s}\n", .{info.manufacturer});
-        std.debug.print(" - Serial #: {s}\n", .{info.serial_number});
+        std.debug.print(" - Serial #: {s}\n", .{info.serial_number});        
+        std.debug.print(" - HW ID: {s}\n", .{info.hw_id});
         std.debug.print(" - VID: 0x{X:0>4} PID: 0x{X:0>4}\n", .{ info.vid, info.pid });
     }
 

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -270,13 +270,15 @@ const WindowsInformationIterator = struct {
         var delimiter: ?[]const u8 = undefined;
         var slice: []const u8 = undefined;
 
-        // TODO: test if this works for anything other than FTDI or using MS CDC driver
         if (std.mem.startsWith(u8, devid, "USB")) {
             delimiter = "\\&";
 
             var parent_id: DEVINST = undefined;
             var local_buffer: [256:0]u8 = std.mem.zeroes([256:0]u8);
 
+            // It appears other approaches recursively scan through parent-child IDs to
+            // find a serial number. This may need further investigation to understand
+            // when/if this is required.
             if (CM_Get_Parent(&parent_id, devinst, 0) != 0) return error.WindowsError;
             if (CM_Get_Device_IDA(parent_id, @ptrCast(&local_buffer), 256, 0) != 0) return error.WindowsError;
 


### PR DESCRIPTION
This is an attempt to add serial port information ([issue #8](https://github.com/ZigEmbeddedGroup/serial/issues/8)) . This is done iteratively via `InformationIterator` which will return a `PortInformation` struct for each serial port.

This PR only adds Windows support. It is (I thought) surprisingly convoluted to get things like the serial number.

I'm thinking perhaps something like a VCP is not handled well but I do not have a device to test.
I have tested with devices using Windows CDC driver and  FTDI.

Referenced implementations :
* qtserialport: https://github.com/qt/qtserialport/blob/dev/src/serialport/qserialportinfo_win.cpp
* pyserial: https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_windows.py

---
Note, I'm very fresh to Zig and I'm sure a lot of this code could be improved. So please, feel free to make edits or suggestions - it would be a good learning experience for me.