### PR TITLE
[Fix] Windows settings

### DIFF
--- a/src/serial.zig
+++ b/src/serial.zig
@@ -667,7 +667,7 @@ pub fn configureSerialPort(port: std.fs.File, config: SerialConfig) !void {
             flags.fParity = if (config.parity != .none) @as(u1, 1) else @as(u1, 0);
             flags.fOutxCtsFlow = if (config.handshake == .hardware) @as(u1, 1) else @as(u1, 0);
             flags.fOutxDsrFlow = 0;
-            flags.fDtrControl = 0;
+            flags.fDtrControl = 1;
             flags.fDsrSensitivity = 0;
             flags.fTXContinueOnXoff = 0;
             flags.fOutX = if (config.handshake == .software) @as(u1, 1) else @as(u1, 0);
@@ -1033,6 +1033,9 @@ test "DCBFlags" {
     try std.testing.expectEqual(rand, flags.toNumeric());
 }
 
+/// Configuration for the serial port
+///
+/// Details: https://learn.microsoft.com/es-es/windows/win32/api/winbase/ns-winbase-dcb
 const DCB = extern struct {
     DCBlength: std.os.windows.DWORD,
     BaudRate: std.os.windows.DWORD,


### PR DESCRIPTION
After some struggle to find out why my simple test code was not reading anything and locking forever, i had to do what we all hate... RTFM

My understanding is that the changed field controls whether the "Terminal" (aka: Windows) is ready to receive data over the serial interface (0=never, 1=always, 2=some protocol is used). So i went ahead and changed `0` -> `1`, it started working :)

I dont quite understand what all the fields mean, so there might be something else that is not correct, but it is at least good enough to run now. Added a link to Windows' docs for QoL when (if) we ever need to revisit these.
