### PR TITLE
Move "Windows-only Warning" out of build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,14 +36,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             });
 
-            // port info only works on Windows!
             // TODO: Linux and MacOS port info support
-            if (std.mem.eql(u8, example_name, "list_port_info") and
-                example.rootModuleTarget().os.tag != .windows)
-            {
-                log.warn("skipping example 'list_port_info' - only supported on Windows", .{});
-                continue;
-            }
 
             example.root_module.addImport("serial", serial_mod);
             const install_example = b.addInstallArtifact(example, .{});

--- a/examples/list.zig
+++ b/examples/list.zig
@@ -6,7 +6,9 @@ pub fn main() !u8 {
     defer iterator.deinit();
 
     while (try iterator.next()) |port| {
-        std.debug.print("path={s},\tname={s},\tdriver={s}\n", .{ port.file_name, port.display_name, port.driver orelse "<no driver recognized>" });
+        std.debug.print("path={s},\tname={s},\tdriver={s}\n", .{
+            port.file_name, port.display_name, port.driver orelse "<no driver recognized>",
+        });
     }
 
     return 0;

--- a/examples/list_port_info.zig
+++ b/examples/list_port_info.zig
@@ -8,7 +8,7 @@ pub fn main() !u8 {
     // TODO: Linux and MacOS port info support
     if (builtin.os.tag != .windows) {
         log.err("'list_port_info' example is only supported on Windows", .{});
-        return 1;
+        std.process.exit(1);
     }
 
     var iterator = try zig_serial.list_info();

--- a/examples/list_port_info.zig
+++ b/examples/list_port_info.zig
@@ -1,7 +1,16 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const zig_serial = @import("serial");
+const log = std.log.scoped(.serial_ex_portinfo);
 
 pub fn main() !u8 {
+
+    // TODO: Linux and MacOS port info support
+    if (builtin.os.tag != .windows) {
+        log.err("'list_port_info' example is only supported on Windows", .{});
+        return 1;
+    }
+
     var iterator = try zig_serial.list_info();
     defer iterator.deinit();
 


### PR DESCRIPTION
I noted that the warning
```
skipping example 'list_port_info' - only supported on Windows
```
from 'list_port_info' being Windows-only pops up whenever `serial` is called as a dependency in a build. I've put that warning in there, so I feel responsible for cleaning up ;-)

I'd move the warning to the example itself, and make it an error that clarifies what's wrong. The list_port_info example would now also be built on Linux for example, but exit with code 1 and print
```
error(serial_ex_portinfo): 'list_port_info' example is only supported on Windows
```