### PR TITLE
Adding port information for Linux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -38,13 +38,6 @@ pub fn build(b: *std.Build) void {
 
             // port info only works on Windows!
             // TODO: Linux and MacOS port info support
-            if (std.mem.eql(u8, example_name, "list_port_info") and
-                example.rootModuleTarget().os.tag != .windows)
-            {
-                log.warn("skipping example 'list_port_info' - only supported on Windows", .{});
-                continue;
-            }
-
             example.root_module.addImport("serial", serial_mod);
             const install_example = b.addInstallArtifact(example, .{});
             example_step.dependOn(&example.step);


### PR DESCRIPTION
# Port Information

I'm inspired from [PySerial](https://github.com/pyserial/pyserial/blob/master/serial/tools/list_ports_linux.py) lib to implement port information iterator for Linux system.
I haven't found equivalent of hw_id for Linux so, I force it to "*N/A*".

This implementation, only work for *usb* and *usb-serial* system. I haven't manage native serial port.

PS: I'm starting with ZIG, so I'm not confident with quality of my code and I'm not sure to use the best solution from std lib.