### PR TITLE
flushSerialPort refactor

### DIFF
--- a/src/serial.zig
+++ b/src/serial.zig
@@ -897,16 +897,15 @@ pub fn configureSerialPort(port: std.fs.File, config: SerialConfig) !void {
     }
 }
 
-/// Flushes the serial port `port`. If `input` is set, all pending data in
-/// the receive buffer is flushed, if `output` is set all pending data in
-/// the send buffer is flushed.
-
 const Flush = enum {
     input,
     output,
     both,
 };
 
+/// Flushes the serial port `port`. If `input` is set, all pending data in
+/// the receive buffer is flushed, if `output` is set all pending data in
+/// the send buffer is flushed.
 pub fn flushSerialPort(port: std.fs.File, flush: Flush) !void {
     switch (builtin.os.tag) {
         .windows => {


### PR DESCRIPTION
The original version of this was bugging me. Traded the two bools for an enum, and then replaced all the if statements for a switch. At least to me this feels like it's a whole lot easier to follow.

Would it be worth it to change the hardcoded TCxFLUSH for linux to termios since its already being used for darwin?