### PR TITLE
Add build step to generate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ The `build.zig` file contains a test step that can be called with `zig build tes
 You can build the examples from the `./examples` directory by calling `zig build examples`. Binaries will be generated in `./zig-out/bin` by default.
 
 - Note that the `list_port_info` example currently only works on Windows
+
+### Building the documentation
+
+You can generate the documentation by running `zig build docs`.
+After that you can browse it by:
+
+ 1. starting the web server. For example, by running `python -m http.server 8000 zig-out/docs`
+ 2. reading the docs from your browser at `http://127.0.0.1:8000`
+

--- a/build.zig
+++ b/build.zig
@@ -44,4 +44,12 @@ pub fn build(b: *std.Build) void {
             example_step.dependOn(&install_example.step);
         }
     }
+    const docs_step = b.step("docs", "Emit documentation");
+
+    const docs_install = b.addInstallDirectory(.{
+        .install_dir = .prefix,
+        .install_subdir = "docs",
+        .source_dir = unit_tests.getEmittedDocs(),
+    });
+    docs_step.dependOn(&docs_install.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,8 @@
 .{
-    .name = "serial",
+    .name = .serial,
     .version = "0.0.1",
+    .minimum_zig_version = "0.14.0",
+    .fingerprint = 0xd374c9dccc91873e,
     .paths = .{
         "src", // all files in src directory
         "README.md",


### PR DESCRIPTION
I propose to add a build step to generate documentation of zig serial.
I also add a readme section to explain how to generate and browse the docs. I'm not sure if my explanation are clear and I'm not English native, so it should be check :-/

PS: I fix build.zig.zon to the new zig.zon convention.