### PR TITLE
Check for zero-sentinel on Windows

### DIFF
--- a/src/serial.zig
+++ b/src/serial.zig
@@ -92,10 +92,17 @@ const WindowsPortIterator = struct {
         self.data_size = 256;
 
         return switch (RegEnumValueA(self.key, self.index, &self.name, &self.name_size, null, null, &self.data, &self.data_size)) {
-            0 => SerialPortDescription{
-                .file_name = try std.fmt.bufPrint(&self.filepath_data, "\\\\.\\{s}", .{self.data[0 .. self.data_size - 1]}),
-                .display_name = self.data[0 .. self.data_size - 1],
-                .driver = self.name[0..self.name_size],
+            0 => ser_desc: {
+                // if zero-sentinel, drop it.
+                if (self.data[self.data_size - 1] == 0) {
+                    self.data_size -= 1;
+                }
+
+                break :ser_desc SerialPortDescription{
+                    .file_name = try std.fmt.bufPrint(&self.filepath_data, "\\\\.\\{s}", .{self.data[0..self.data_size]}),
+                    .display_name = self.data[0..self.data_size],
+                    .driver = self.name[0..self.name_size],
+                };
             },
             259 => null,
             else => error.WindowsError,
@@ -246,6 +253,10 @@ const WindowsInformationIterator = struct {
 
             // if this is valid, return now
             if (result == 0 and port_length > 0) {
+                // if zero-sentinel, drop it.
+                if (port_name[port_length - 1] == 0) {
+                    port_length -= 1;
+                }
                 return port_length;
             }
         }


### PR DESCRIPTION
For Windows COM ports, check whether the last byte is a zero-sentinel or not instead of assuming.

Closes https://github.com/ZigEmbeddedGroup/serial/issues/43

<details>
<summary>list.exe [master]</summary>
  Note the BthModem COM ports are one character too short
 
```
  path=\\.\COM,   name=COM,       driver=\Device\BthModem6 
  path=\\.\COM3,  name=COM3,      driver=\Device\BthModem4  
  path=\\.\COM,   name=COM,       driver=\Device\BthModem2 
  path=\\.\COM3,  name=COM3,      driver=\Device\BthModem0 
  path=\\.\COM2,  name=COM2,      driver=\Device\BthModem1 
  path=\\.\COM2,  name=COM2,      driver=\Device\BthModem3 
  path=\\.\COM26, name=COM26,     driver=\Device\VCP0
```
</details>

<details>
<summary>list.exe [branch]</summary>
 
```
  path=\\.\COM24, name=COM24,     driver=\Device\BthModem5
  path=\\.\COM3,  name=COM3,      driver=\Device\BthModem6
  path=\\.\COM30, name=COM30,     driver=\Device\BthModem4
  path=\\.\COM5,  name=COM5,      driver=\Device\BthModem2
  path=\\.\COM31, name=COM31,     driver=\Device\BthModem0
  path=\\.\COM29, name=COM29,     driver=\Device\BthModem1
  path=\\.\COM22, name=COM22,     driver=\Device\BthModem3
  path=\\.\COM26, name=COM26,     driver=\Device\VCP0
```
</details>