### PR TITLE
macOS implementation of InformationIterator

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,11 +15,23 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/serial.zig"),
     });
 
+    // Add platform-specific linking for macOS
+    if (target.result.os.tag == .macos) {
+        serial_mod.linkFramework("IOKit", .{});
+        serial_mod.linkFramework("CoreFoundation", .{});
+    }
+
     const unit_tests = b.addTest(.{
         .root_source_file = b.path("src/serial.zig"),
         .target = target,
         .optimize = optimize,
     });
+
+    // Add platform-specific linking for macOS
+    if (target.result.os.tag == .macos) {
+        unit_tests.linkFramework("IOKit");
+        unit_tests.linkFramework("CoreFoundation");
+    }
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
@@ -39,6 +51,13 @@ pub fn build(b: *std.Build) void {
             // port info only works on Windows!
             // TODO: Linux and MacOS port info support
             example.root_module.addImport("serial", serial_mod);
+
+            // Add platform-specific linking for macOS
+            if (target.result.os.tag == .macos) {
+                example.linkFramework("IOKit");
+                example.linkFramework("CoreFoundation");
+            }
+
             const install_example = b.addInstallArtifact(example, .{});
             example_step.dependOn(&example.step);
             example_step.dependOn(&install_example.step);

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -1158,7 +1158,13 @@ test "basic configuration test" {
         else => unreachable,
     }
 
-    var port = try std.fs.cwd().openFile(tty, .{ .mode = .read_write });
+    var port = std.fs.cwd().openFile(tty, .{ .mode = .read_write }) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.log.warn("Serial port {s} not found, skipping test", .{tty});
+            return;
+        },
+        else => return err,
+    };
     defer port.close();
 
     try configureSerialPort(port, cfg);
@@ -1173,7 +1179,13 @@ test "basic flush test" {
         .macos => tty = "/dev/cu.usbmodem101",
         else => unreachable,
     }
-    var port = try std.fs.cwd().openFile(tty, .{ .mode = .read_write });
+    var port = std.fs.cwd().openFile(tty, .{ .mode = .read_write }) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.log.warn("Serial port {s} not found, skipping test", .{tty});
+            return;
+        },
+        else => return err,
+    };
     defer port.close();
 
     try flushSerialPort(port, .both);


### PR DESCRIPTION
the output of zig-out/bin/list_port_info on my system now looks like this:

```txt
Port name: cu.debug-console
 - System location: /dev/cu.debug-console
 - Friendly name: cu.debug-console
 - Description: Serial Device
 - Manufacturer: Unknown
 - Serial #: N/A
 - HW ID: macOS:cu.debug-console
 - VID: 0x0000 PID: 0x0000

Port name: cu.Bluetooth-Incoming-Port
 - System location: /dev/cu.Bluetooth-Incoming-Port
 - Friendly name: cu.Bluetooth-Incoming-Port
 - Description: Bluetooth Serial Device
 - Manufacturer: Unknown
 - Serial #: N/A
 - HW ID: macOS:cu.Bluetooth-Incoming-Port
 - VID: 0x0000 PID: 0x0000

Port name: cu.usbmodem5buspirate1
 - System location: /dev/cu.usbmodem5buspirate1
 - Friendly name: cu.usbmodem5buspirate1
 - Description: Bus Pirate 5
 - Manufacturer: Bus Pirate
 - Serial #: 5buspirate
 - HW ID: macOS:cu.usbmodem5buspirate1
 - VID: 0x1209 PID: 0x7331

Port name: cu.usbmodem5buspirate3
 - System location: /dev/cu.usbmodem5buspirate3
 - Friendly name: cu.usbmodem5buspirate3
 - Description: Bus Pirate 5
 - Manufacturer: Bus Pirate
 - Serial #: 5buspirate
 - HW ID: macOS:cu.usbmodem5buspirate3
 - VID: 0x1209 PID: 0x7331

Port name: cu.usbmodem7132301
 - System location: /dev/cu.usbmodem7132301
 - Friendly name: cu.usbmodem7132301
 - Description: HydraBus 1_0 COM Port1
 - Manufacturer: Openmoko, Inc.
 - Serial #: 0030002A6131571920533652
 - HW ID: macOS:cu.usbmodem7132301
 - VID: 0x1D50 PID: 0x60A7
```

the output of zig-out/bin/list:

```txt
path=/dev/cu.debug-console,     name=/dev/cu.debug-console,     driver=darwin
path=/dev/cu.Bluetooth-Incoming-Port,   name=/dev/cu.Bluetooth-Incoming-Port,   driver=darwin
path=/dev/cu.usbmodem5buspirate1,       name=/dev/cu.usbmodem5buspirate1,       driver=darwin
path=/dev/cu.usbmodem5buspirate3,       name=/dev/cu.usbmodem5buspirate3,       driver=darwin
path=/dev/cu.usbmodem7132301,   name=/dev/cu.usbmodem7132301,   driver=darwin
```