### PR TITLE
Update windows calling convention for zig 0.15.1

### DIFF
--- a/src/serial.zig
+++ b/src/serial.zig
@@ -395,8 +395,8 @@ extern "advapi32" fn RegOpenKeyExA(
     ulOptions: std.os.windows.DWORD,
     samDesired: std.os.windows.REGSAM,
     phkResult: *HKEY,
-) callconv(std.os.windows.WINAPI) std.os.windows.LSTATUS;
-extern "advapi32" fn RegCloseKey(key: HKEY) callconv(std.os.windows.WINAPI) std.os.windows.LSTATUS;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
+extern "advapi32" fn RegCloseKey(key: HKEY) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
 extern "advapi32" fn RegEnumValueA(
     hKey: HKEY,
     dwIndex: std.os.windows.DWORD,
@@ -406,7 +406,7 @@ extern "advapi32" fn RegEnumValueA(
     lpType: ?*std.os.windows.DWORD,
     lpData: [*]std.os.windows.BYTE,
     lpcbData: *std.os.windows.DWORD,
-) callconv(std.os.windows.WINAPI) std.os.windows.LSTATUS;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
 extern "advapi32" fn RegQueryValueExA(
     hKey: HKEY,
     lpValueName: std.os.windows.LPSTR,
@@ -414,19 +414,19 @@ extern "advapi32" fn RegQueryValueExA(
     lpType: ?*std.os.windows.DWORD,
     lpData: ?[*]std.os.windows.BYTE,
     lpcbData: ?*std.os.windows.DWORD,
-) callconv(std.os.windows.WINAPI) std.os.windows.LSTATUS;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
 extern "setupapi" fn SetupDiGetClassDevsW(
     classGuid: ?*const std.os.windows.GUID,
     enumerator: ?std.os.windows.PCWSTR,
     hwndParanet: ?HWND,
     flags: std.os.windows.DWORD,
-) callconv(std.os.windows.WINAPI) HDEVINFO;
+) callconv(std.builtin.CallingConvention.winapi) HDEVINFO;
 extern "setupapi" fn SetupDiEnumDeviceInfo(
     devInfoSet: HDEVINFO,
     memberIndex: std.os.windows.DWORD,
     device_info_data: *SP_DEVINFO_DATA,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
-extern "setupapi" fn SetupDiDestroyDeviceInfoList(device_info_set: HDEVINFO) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+extern "setupapi" fn SetupDiDestroyDeviceInfoList(device_info_set: HDEVINFO) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 extern "setupapi" fn SetupDiOpenDevRegKey(
     device_info_set: HDEVINFO,
     device_info_data: *SP_DEVINFO_DATA,
@@ -434,7 +434,7 @@ extern "setupapi" fn SetupDiOpenDevRegKey(
     hwProfile: std.os.windows.DWORD,
     keyType: std.os.windows.DWORD,
     samDesired: std.os.windows.REGSAM,
-) callconv(std.os.windows.WINAPI) HKEY;
+) callconv(std.builtin.CallingConvention.winapi) HKEY;
 extern "setupapi" fn SetupDiGetDeviceRegistryPropertyA(
     hDevInfo: HDEVINFO,
     pSpDevInfoData: *SP_DEVINFO_DATA,
@@ -443,25 +443,25 @@ extern "setupapi" fn SetupDiGetDeviceRegistryPropertyA(
     propertyBuffer: ?[*]std.os.windows.BYTE,
     propertyBufferSize: std.os.windows.DWORD,
     requiredSize: ?*std.os.windows.DWORD,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 extern "setupapi" fn SetupDiGetDeviceInstanceIdA(
     device_info_set: HDEVINFO,
     device_info_data: *SP_DEVINFO_DATA,
     deviceInstanceId: *?std.os.windows.CHAR,
     deviceInstanceIdSize: std.os.windows.DWORD,
     requiredSize: ?*std.os.windows.DWORD,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 extern "cfgmgr32" fn CM_Get_Parent(
     pdnDevInst: *DEVINST,
     dnDevInst: DEVINST,
     ulFlags: std.os.windows.ULONG,
-) callconv(std.os.windows.WINAPI) std.os.windows.DWORD;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.DWORD;
 extern "cfgmgr32" fn CM_Get_Device_IDA(
     dnDevInst: DEVINST,
     buffer: std.os.windows.LPSTR,
     bufferLen: std.os.windows.ULONG,
     ulFlags: std.os.windows.ULONG,
-) callconv(std.os.windows.WINAPI) std.os.windows.DWORD;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.DWORD;
 
 const LinuxPortIterator = struct {
     const Self = @This();
@@ -1026,8 +1026,8 @@ const PURGE_RXCLEAR = 0x0008;
 const PURGE_TXABORT = 0x0001;
 const PURGE_TXCLEAR = 0x0004;
 
-extern "kernel32" fn PurgeComm(hFile: std.os.windows.HANDLE, dwFlags: std.os.windows.DWORD) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
-extern "kernel32" fn EscapeCommFunction(hFile: std.os.windows.HANDLE, dwFunc: std.os.windows.DWORD) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+extern "kernel32" fn PurgeComm(hFile: std.os.windows.HANDLE, dwFlags: std.os.windows.DWORD) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+extern "kernel32" fn EscapeCommFunction(hFile: std.os.windows.HANDLE, dwFunc: std.os.windows.DWORD) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 fn mapBaudToLinuxEnum(baudrate: usize) !std.c.speed_t {
     return switch (baudrate) {
@@ -1134,8 +1134,8 @@ const DCB = extern struct {
     wReserved1: std.os.windows.WORD,
 };
 
-extern "kernel32" fn GetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
-extern "kernel32" fn SetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+extern "kernel32" fn GetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+extern "kernel32" fn SetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 test "iterate ports" {
     var it = try list();

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -395,8 +395,8 @@ extern "advapi32" fn RegOpenKeyExA(
     ulOptions: std.os.windows.DWORD,
     samDesired: std.os.windows.REGSAM,
     phkResult: *HKEY,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
-extern "advapi32" fn RegCloseKey(key: HKEY) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
+) callconv(.winapi) std.os.windows.LSTATUS;
+extern "advapi32" fn RegCloseKey(key: HKEY) callconv(.winapi) std.os.windows.LSTATUS;
 extern "advapi32" fn RegEnumValueA(
     hKey: HKEY,
     dwIndex: std.os.windows.DWORD,
@@ -406,7 +406,7 @@ extern "advapi32" fn RegEnumValueA(
     lpType: ?*std.os.windows.DWORD,
     lpData: [*]std.os.windows.BYTE,
     lpcbData: *std.os.windows.DWORD,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
+) callconv(.winapi) std.os.windows.LSTATUS;
 extern "advapi32" fn RegQueryValueExA(
     hKey: HKEY,
     lpValueName: std.os.windows.LPSTR,
@@ -414,19 +414,19 @@ extern "advapi32" fn RegQueryValueExA(
     lpType: ?*std.os.windows.DWORD,
     lpData: ?[*]std.os.windows.BYTE,
     lpcbData: ?*std.os.windows.DWORD,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LSTATUS;
+) callconv(.winapi) std.os.windows.LSTATUS;
 extern "setupapi" fn SetupDiGetClassDevsW(
     classGuid: ?*const std.os.windows.GUID,
     enumerator: ?std.os.windows.PCWSTR,
     hwndParanet: ?HWND,
     flags: std.os.windows.DWORD,
-) callconv(std.builtin.CallingConvention.winapi) HDEVINFO;
+) callconv(.winapi) HDEVINFO;
 extern "setupapi" fn SetupDiEnumDeviceInfo(
     devInfoSet: HDEVINFO,
     memberIndex: std.os.windows.DWORD,
     device_info_data: *SP_DEVINFO_DATA,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
-extern "setupapi" fn SetupDiDestroyDeviceInfoList(device_info_set: HDEVINFO) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+) callconv(.winapi) std.os.windows.BOOL;
+extern "setupapi" fn SetupDiDestroyDeviceInfoList(device_info_set: HDEVINFO) callconv(.winapi) std.os.windows.BOOL;
 extern "setupapi" fn SetupDiOpenDevRegKey(
     device_info_set: HDEVINFO,
     device_info_data: *SP_DEVINFO_DATA,
@@ -434,7 +434,7 @@ extern "setupapi" fn SetupDiOpenDevRegKey(
     hwProfile: std.os.windows.DWORD,
     keyType: std.os.windows.DWORD,
     samDesired: std.os.windows.REGSAM,
-) callconv(std.builtin.CallingConvention.winapi) HKEY;
+) callconv(.winapi) HKEY;
 extern "setupapi" fn SetupDiGetDeviceRegistryPropertyA(
     hDevInfo: HDEVINFO,
     pSpDevInfoData: *SP_DEVINFO_DATA,
@@ -443,25 +443,25 @@ extern "setupapi" fn SetupDiGetDeviceRegistryPropertyA(
     propertyBuffer: ?[*]std.os.windows.BYTE,
     propertyBufferSize: std.os.windows.DWORD,
     requiredSize: ?*std.os.windows.DWORD,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+) callconv(.winapi) std.os.windows.BOOL;
 extern "setupapi" fn SetupDiGetDeviceInstanceIdA(
     device_info_set: HDEVINFO,
     device_info_data: *SP_DEVINFO_DATA,
     deviceInstanceId: *?std.os.windows.CHAR,
     deviceInstanceIdSize: std.os.windows.DWORD,
     requiredSize: ?*std.os.windows.DWORD,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+) callconv(.winapi) std.os.windows.BOOL;
 extern "cfgmgr32" fn CM_Get_Parent(
     pdnDevInst: *DEVINST,
     dnDevInst: DEVINST,
     ulFlags: std.os.windows.ULONG,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.DWORD;
+) callconv(.winapi) std.os.windows.DWORD;
 extern "cfgmgr32" fn CM_Get_Device_IDA(
     dnDevInst: DEVINST,
     buffer: std.os.windows.LPSTR,
     bufferLen: std.os.windows.ULONG,
     ulFlags: std.os.windows.ULONG,
-) callconv(std.builtin.CallingConvention.winapi) std.os.windows.DWORD;
+) callconv(.winapi) std.os.windows.DWORD;
 
 const LinuxPortIterator = struct {
     const Self = @This();
@@ -1026,8 +1026,8 @@ const PURGE_RXCLEAR = 0x0008;
 const PURGE_TXABORT = 0x0001;
 const PURGE_TXCLEAR = 0x0004;
 
-extern "kernel32" fn PurgeComm(hFile: std.os.windows.HANDLE, dwFlags: std.os.windows.DWORD) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
-extern "kernel32" fn EscapeCommFunction(hFile: std.os.windows.HANDLE, dwFunc: std.os.windows.DWORD) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+extern "kernel32" fn PurgeComm(hFile: std.os.windows.HANDLE, dwFlags: std.os.windows.DWORD) callconv(.winapi) std.os.windows.BOOL;
+extern "kernel32" fn EscapeCommFunction(hFile: std.os.windows.HANDLE, dwFunc: std.os.windows.DWORD) callconv(.winapi) std.os.windows.BOOL;
 
 fn mapBaudToLinuxEnum(baudrate: usize) !std.c.speed_t {
     return switch (baudrate) {
@@ -1134,8 +1134,8 @@ const DCB = extern struct {
     wReserved1: std.os.windows.WORD,
 };
 
-extern "kernel32" fn GetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
-extern "kernel32" fn SetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
+extern "kernel32" fn GetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(.winapi) std.os.windows.BOOL;
+extern "kernel32" fn SetCommState(hFile: std.os.windows.HANDLE, lpDCB: *DCB) callconv(.winapi) std.os.windows.BOOL;
 
 test "iterate ports" {
     var it = try list();


### PR DESCRIPTION
Resolves #48 

Updates windows calling convention from std.os.windows.WINAPI to std.builtin.CallingConvention.winapi.