### PR TITLE
Fix errors with 0.16.0 update

### DIFF
--- a/examples/echo.zig
+++ b/examples/echo.zig
@@ -4,7 +4,7 @@ const zig_serial = @import("serial");
 pub fn main(init: std.process.Init) !u8 {
     const port_name = if (@import("builtin").os.tag == .windows) "\\\\.\\COM1" else "/dev/ttyUSB0";
 
-    var serial = std.Io.Dir.cwd().openFile(init.io, port_name, .{ .mode = .read_write }) catch |err| switch (err) {
+    var serial = std.Io.Dir.openFileAbsolute(init.io, port_name, .{ .mode = .read_write }) catch |err| switch (err) {
         error.FileNotFound => {
             std.debug.print("Invalid config: the serial port '{s}' does not exist.\n", .{port_name});
             return 1;

--- a/examples/list.zig
+++ b/examples/list.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const zig_serial = @import("serial");
 
-pub fn main() !u8 {
-    var iterator = try zig_serial.list();
+pub fn main(init: std.process.Init) !u8 {
+    var iterator = try zig_serial.list(init.io);
     defer iterator.deinit();
 
     while (try iterator.next()) |port| {

--- a/examples/list_port_info.zig
+++ b/examples/list_port_info.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const zig_serial = @import("serial");
 
-pub fn main() !u8 {
-    var iterator = try zig_serial.list_info();
+pub fn main(init: std.process.Init) !u8 {
+    var iterator = try zig_serial.list_info(init.io);
     defer iterator.deinit();
 
     while (try iterator.next()) |info| {

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -477,7 +477,7 @@ const LinuxPortIterator = struct {
     driver_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
 
     pub fn init(io: std.Io) !Self {
-        var dir = try std.Io.Dir.cwd().openDir(io, root_dir, .{ .iterate = true });
+        var dir = try std.Io.Dir.openDirAbsolute(io, root_dir, .{ .iterate = true });
         errdefer dir.close(io);
 
         return Self{
@@ -548,7 +548,7 @@ const LinuxInformationIterator = struct {
     port: PortInformation = undefined,
 
     pub fn init(io: std.Io) !Self {
-        var dir = try std.Io.Dir.cwd().openDir(io, root_dir, .{ .iterate = true });
+        var dir = try std.Io.Dir.openDirAbsolute(io, root_dir, .{ .iterate = true });
         errdefer dir.close(io);
 
         return Self{ .index = 0, .io = io, .dir = dir, .iterator = dir.iterate() };
@@ -608,7 +608,7 @@ const LinuxInformationIterator = struct {
                 return self.port;
             }
 
-            var data_dir = std.Io.Dir.openDirAbsolute(self.io, device_path, .{}) catch continue;
+            var data_dir = std.Io.Dir.openDirAbsolute(self.io, self.driver_path_buffer[0..device_path], .{}) catch continue;
             defer data_dir.close(self.io);
             var tmp: [4]u8 = undefined;
             {
@@ -657,7 +657,7 @@ const DarwinPortIterator = struct {
     driver_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
 
     pub fn init(io: std.Io) !Self {
-        var dir = try std.Io.Dir.cwd().openDir(io, root_dir, .{ .iterate = true });
+        var dir = try std.Io.Dir.openDirAbsolute(io, root_dir, .{ .iterate = true });
         errdefer dir.close();
 
         return Self{
@@ -1171,7 +1171,7 @@ test "basic configuration test" {
 
     var threaded = Io.Threaded.init_single_threaded;
     const io = threaded.io();
-    var port = try std.Io.Dir.cwd().openFile(io, tty, .{ .mode = .read_write });
+    var port = try std.Io.Dir.openFileAbsolute(io, tty, .{ .mode = .read_write });
     defer port.close(io);
 
     try configureSerialPort(port, cfg);
@@ -1188,7 +1188,7 @@ test "basic flush test" {
     }
     var threaded = Io.Threaded.init_single_threaded;
     const io = threaded.io();
-    var port = try std.Io.Dir.cwd().openFile(io, tty, .{ .mode = .read_write });
+    var port = try std.Io.Dir.openFileAbsolute(io, tty, .{ .mode = .read_write });
     defer port.close(io);
 
     try flushSerialPort(port, .both);

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -514,7 +514,7 @@ const LinuxPortIterator = struct {
                 defer device_dir.close(self.io);
 
                 // We need the symlink for "driver"
-                const link = device_dir.readLink(self.io, "driver", &self.driver_path_buffer) catch continue;
+                const link_len = device_dir.readLink(self.io, "driver", &self.driver_path_buffer) catch continue;
 
                 // full_path_buffer
                 // driver_path_buffer
@@ -529,7 +529,7 @@ const LinuxPortIterator = struct {
                 return SerialPortDescription{
                     .file_name = path,
                     .display_name = path,
-                    .driver = std.fs.path.basename(link),
+                    .driver = std.fs.path.basename(self.driver_path_buffer[0..link_len]),
                 };
             } else {
                 return null;
@@ -598,15 +598,15 @@ const LinuxInformationIterator = struct {
                 self.port.hw_id = "N/A";
             }
             // We need the symlink for "driver"
-            const subsystem_path = device_dir.readLink(self.io, "subsystem", &self.driver_path_buffer) catch continue;
-            const subsystem = std.fs.path.basename(subsystem_path);
-            var device_path: []u8 = undefined;
+            const subsystem_link_len = device_dir.readLink(self.io, "subsystem", &self.driver_path_buffer) catch continue;
+            const subsystem = std.fs.path.basename(self.driver_path_buffer[0..subsystem_link_len]);
+            var device_path_len: usize = undefined;
             if (std.mem.eql(u8, subsystem, "usb") == true) {
                 const parent = try device_dir.openDir(self.io, "../", .{});
-                device_path = try parent.realPath(self.io, &self.driver_path_buffer);
+                device_path_len = try parent.realPath(self.io, &self.driver_path_buffer);
             } else if (std.mem.eql(u8, subsystem, "usb-serial") == true) {
                 const parent = try device_dir.openDir(self.io, "../../", .{});
-                device_path = try parent.realPath(self.io, &self.driver_path_buffer);
+                device_path_len = try parent.realPath(self.io, &self.driver_path_buffer);
             } else {
                 //must be remove to manage other device type
                 self.port.description = "Not Managed";
@@ -617,7 +617,7 @@ const LinuxInformationIterator = struct {
                 return self.port;
             }
 
-            var data_dir = std.Io.Dir.openDirAbsolute(self.io, self.driver_path_buffer[0..device_path], .{}) catch continue;
+            var data_dir = std.Io.Dir.openDirAbsolute(self.io, self.driver_path_buffer[0..device_path_len], .{}) catch continue;
             defer data_dir.close(self.io);
             var tmp: [4]u8 = undefined;
             {

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -3,12 +3,21 @@ const builtin = @import("builtin");
 const c = @cImport(@cInclude("termios.h"));
 const Io = std.Io;
 
-pub fn list() !PortIterator {
-    return try PortIterator.init();
+pub fn list(io: Io) !PortIterator {
+    return try switch (builtin.os.tag) {
+        .windows => WindowsPortIterator.init(),
+        .linux => LinuxPortIterator.init(io),
+        .macos => DarwinPortIterator.init(io),
+        else => @compileError("OS is not supported for port iteration"),
+    };
 }
 
-pub fn list_info() !InformationIterator {
-    return try InformationIterator.init();
+pub fn list_info(io: Io) !InformationIterator {
+    return try switch (builtin.os.tag) {
+        .windows => WindowsInformationIterator.init(),
+        .linux => LinuxInformationIterator.init(io),
+        else => @compileError("OS is not supported for information iteration"),
+    };
 }
 
 pub const PortIterator = switch (builtin.os.tag) {
@@ -471,7 +480,7 @@ const LinuxPortIterator = struct {
 
     io: std.Io,
     dir: std.Io.Dir,
-    iterator: std.fs.Dir.Iterator,
+    iterator: std.Io.Dir.Iterator,
 
     full_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
     driver_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
@@ -494,7 +503,7 @@ const LinuxPortIterator = struct {
 
     pub fn next(self: *Self) !?SerialPortDescription {
         while (true) {
-            if (try self.iterator.next()) |entry| {
+            if (try self.iterator.next(self.io)) |entry| {
                 // not a dir => we don't care
                 var tty_dir = self.dir.openDir(self.io, entry.name, .{}) catch continue;
                 defer tty_dir.close(self.io);
@@ -538,7 +547,7 @@ const LinuxInformationIterator = struct {
     index: u8,
     io: std.Io,
     dir: std.Io.Dir,
-    iterator: std.fs.Dir.Iterator,
+    iterator: std.Io.Dir.Iterator,
 
     driver_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
     sys_buffer: [256:0]u8 = undefined,
@@ -561,7 +570,7 @@ const LinuxInformationIterator = struct {
 
     pub fn next(self: *Self) !?PortInformation {
         self.index += 1;
-        while (try self.iterator.next()) |entry| {
+        while (try self.iterator.next(self.io)) |entry| {
             @memset(&self.sys_buffer, 0);
             @memset(&self.desc_buffer, 0);
             @memset(&self.man_buffer, 0);
@@ -651,7 +660,7 @@ const DarwinPortIterator = struct {
 
     io: std.Io,
     dir: std.Io.Dir,
-    iterator: std.fs.Dir.Iterator,
+    iterator: std.Io.Dir.Iterator,
 
     full_path_buffer: [std.fs.max_path_bytes]u8 = undefined,
     driver_path_buffer: [std.fs.max_path_bytes]u8 = undefined,


### PR DESCRIPTION
I attempted to build the master branch of serial for Zig 0.16.0, but discovered compile errors because of code using `std.fs.Dir.Iterator`, which wasn't an existing member, as it was moved to `std.Io.Dir`, which required an update, and a slight change of logic for `list` and `list_info` functions.

Another issue was the return value of `std.Io.Dir.readLink`, which is of type usize and represents the length of symlink, being passed into `std.fs.path.basename`, which takes a byte buffer in.

A lesser, but noticeable issue was the use of `std.Io.Dir.cwd().openDir` meant for relative paths with absolute file paths to serial ports, which I swapped for more semantically correct `std.Io.Dir.openDirAbsolute`. Same for `openFile` in echo example.